### PR TITLE
Recery Bot 1.0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .env
 
 node_modules/
+ServerModule/

--- a/commands/economy/almanac.js
+++ b/commands/economy/almanac.js
@@ -22,6 +22,7 @@ module.exports = {
         const lang = client.langs.get(msg.guildId) || "es";
         const userID = msg.author.id;
 
+        const loadingReaction = await msg.react("<a:Loading:1334664535914844253>");
         const imageAttachments = await getAlmanacImages(eco.getTotalSlimes(userID), lang);
 
         const buttonsRow = new Discord.ActionRowBuilder()
@@ -55,6 +56,8 @@ module.exports = {
             files: [imageAttachments[page]],
             components: [buttonsRow]
         });
+
+        loadingReaction.users.remove(client.user.id);
 
         /// MENSAJE ENVIADO, AHORA ACTUALIZACION DEL MENSAJE
 

--- a/commands/economy/barn.js
+++ b/commands/economy/barn.js
@@ -348,7 +348,6 @@ module.exports = {
         let subcommandName = args.shift();
         if (subcommandName) subcommandName = subcommandName.toLowerCase().trim();
         for (const subcommand of this.subcommands) {
-            //console.log(subcommand.name, subcommandName);
             if (subcommand.name === subcommandName) {
                 subcommand.execute(client, msg, args);
                 return;
@@ -367,6 +366,8 @@ module.exports = {
             content += "`ID: " + slime.obj.id.toString() + "` "; // Agregar el id primero
             content += slime.obj.displayName[lang] + " x" + slime.quantity.toString() + "\n";
         }
+
+        const loadingReaction = await msg.react("<a:Loading:1334664535914844253>");
 
         let page = 0; // Página 0 = página 1 para el usuario
 
@@ -419,6 +420,8 @@ module.exports = {
             files: [images[page]],
             components: [buttonsRow]
         });
+
+        loadingReaction.users.remove(client.user.id);
 
         const collector = sentMessage.createMessageComponentCollector({time: 120000});
         const messageDeleteListener = (deletedMessage) => {

--- a/commands/economy/corral.js
+++ b/commands/economy/corral.js
@@ -22,6 +22,8 @@ module.exports = {
 
         const slimesInCorral = eco.getCorralSlimes(userID);
 
+        const loadingReaction = await msg.react("<a:Loading:1334664535914844253>");
+
         let page = 0; // Página 0 = página 1 para el usuario
         const images = await getImagesAttachment(slimesInCorral, lang);
 
@@ -70,6 +72,8 @@ module.exports = {
             files: [images[page]],
             components: [buttonsRow]
         });
+
+        loadingReaction.users.remove(client.user.id);
 
         const collector = sentMessage.createMessageComponentCollector({time: 120000});
         const messageDeleteListener = (deletedMessage) => {

--- a/commands/economy/hatchSlimes.js
+++ b/commands/economy/hatchSlimes.js
@@ -76,7 +76,7 @@ module.exports = {
             files: [imageAttachment]
         });
 
-        loadingReaction.remove();
+        loadingReaction.users.remove(client.user.id);
     }
 }
 

--- a/economy/slimesModule.js
+++ b/economy/slimesModule.js
@@ -185,10 +185,10 @@ const slimes = [
         banner: banners.VOCALOID
     },
     {
-        name: "greenappleslime",
+        name: "appleslime",
         displayName: {
-            es: "Slime Manzana Verde",
-            en: "Green Apple Slime"
+            es: "Slime Manzana",
+            en: "Apple Slime"
         },
         id: 16,
         rarity: 4,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('dotenv').config();
 const Discord = require("discord.js");
 
 const client = new Discord.Client({
@@ -19,6 +19,9 @@ client.on(Discord.Events.MessageCreate, (msg) => {
 	if (process.env.EXPERIMENTAL)
 		if (msg.author.id !== "1069155273182285834" && msg.author.id !== "1296846133489963049") return;
 	
+	const channel = msg.guild.channels.cache.get(msg.channelId);
+	if (!(channel && msg.guild.members.me.permissionsIn(channel).has('SendMessages'))) return;
+
 	const cleanText = Prefix.cleanPrefix(msg, client.user.id);
 
 	if (!cleanText || msg.author.bot) return;


### PR DESCRIPTION
fixed a bug where the bot was not allowed to remove reactions because of not having permissions. Now it removes only the reactions that he made.

Also added a verification to see if the bot is allowed to send messages in a channel. If not, it will not reply to the command, preventing crashes.